### PR TITLE
Fixed updating of Environment Variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A portainer github action to let you update your stacks
 2. Put the following step in the file
 ```yaml
       - name: portainer
-        uses: luminos-company/portami@v1.1
+        uses: luminos-company/portami@v1.2
         with:
           endpoint: 'https://myportainer.example.com'
           access_token: 'REALLY SECRET TOKEN'

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A portainer github action to let you update your stacks
         with:
           endpoint: 'https://myportainer.example.com'
           access_token: 'REALLY SECRET TOKEN'
-          stack_id: 'my_stack_name' # The unique name of the stack like: "cdn_minio"
+          stack_name: 'my_stack_name' # The unique name of the stack like: "cdn_minio"
           file_path: 'my_awesome_stack_file.yaml' # The stack file path to use
           prune: true # Prune the stack
           pull: true # Pull the images
@@ -26,7 +26,7 @@ A portainer github action to let you update your stacks
 | ---- | ----------- | -------- | ------- |
 | endpoint | The portainer endpoint | true | |
 | access_token | The portainer access token | true | |
-| stack_id | The stack id | true | |
+| stack_name | The stack id | true | |
 | file_path | The stack file path | false | |
 | prune | Prune the stack | false | false |
 | pull | Pull the images | false | false |

--- a/action.yml
+++ b/action.yml
@@ -10,8 +10,8 @@ inputs:
   access_token: 
     description: 'User access token with the right privilegis'
     required: true
-  stack_id: 
-    description: 'Stack id'
+  stack_name: 
+    description: 'Stack name'
     required: true  
   file_path: 
     description: 'Path to the file to be updated'

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ import * as fs from 'fs';
 import fetch from 'node-fetch';
 
 const endpoint = core.getInput('endpoint')+"/api";
-const stack_id = core.getInput('stack_id');
+const stack_name = core.getInput('stack_name');
 const file_path = core.getInput('file_path');
 const prune = core.getBooleanInput('prune');
 const pullImage = core.getBooleanInput('pull');
@@ -22,14 +22,14 @@ function withQuery(url, query) {
 }
 
 async function fetchStack() {
-    await fetch(withQuery(endpoint+'/stacks'),
+    await fetch(withQuery(endpoint + '/stacks'),
         {
             headers: headers,
         })
         .then(response => response.json())
         .then(async (data) => {
             for (let i = 0; i < data.length; i++) {
-                if (data[i].Name == stack_id) {
+                if (data[i].Name == stack_name) {
                     await fetchStackID(data[i].Id);
                     break;
                 }
@@ -38,22 +38,21 @@ async function fetchStack() {
 }
 
 async function fetchStackID(id) {
-    await fetch(withQuery(endpoint+'/stacks/' + id),
+    await fetch(withQuery(endpoint + '/stacks/' + id),
         {
             headers: headers,
         })
         .then(response => response.json())
         .then(async (data) => {
-            await redoploy(data.Id, data.EndpointId);
+            await redoploy(data.Id, data.EndpointId, data.Env);
         });
 }
 
-async function redoploy(id, endpointId) {
+async function redoploy(id, endpointId, basicVars) {
     let basicContent = "";
-    let basicVars = [];
     try {
         try {
-            let res = (await fetch(endpoint+'/stacks/' + id + '/file', {
+            let res = (await fetch(endpoint + '/stacks/' + id + '/file', {
                 method: 'GET',
                 headers: headers,
             }).then(response => response.json()));
@@ -64,9 +63,6 @@ async function redoploy(id, endpointId) {
             }
         } catch (error) {
             core.setFailed("This stack is not a file stack");
-        }
-        if (res.Env) {
-            basicVars = res.Env;
         }
     } catch (_) {
     }
@@ -81,7 +77,7 @@ async function redoploy(id, endpointId) {
         "value": new Date().toISOString()
     });
 
-    await fetch(withQuery(endpoint+'/stacks/' + id, {
+    await fetch(withQuery(endpoint + '/stacks/' + id, {
         "endpointId": endpointId,
     }),
         {

--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ async function redoploy(id, endpointId, basicVars) {
         "value": "true"
     }, {
         "name": "PORTAMI_VERSION",
-        "value": "v1.1"
+        "value": "v1.2"
     }, {
         "name": "PORTAMI_UPDATED_AT",
         "value": new Date().toISOString()


### PR DESCRIPTION
Previously, the action tried to grab the existing environment variables from the `stacks/{id}/file` endpoint, however this only returns `"StackFileContent"` - environment variables should be grabbed from the `stacks/{id}` endpoint, see https://app.swaggerhub.com/apis/portainer/portainer-ce/2.18.3.

Also renamed the `stack_id` input to `stack_name`, as this actio uses the `stack_name` to get the `stack_id` from the API. 